### PR TITLE
Added entity/group option for query builder

### DIFF
--- a/demo/esm/src/app/app.component.ts
+++ b/demo/esm/src/app/app.component.ts
@@ -42,10 +42,19 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from '../../lib/components
         <mat-radio-button [style.padding.px]="10" value="or">Or</mat-radio-button>
       </mat-radio-group>
     </ng-container>
-    <ng-container *queryField="let rule; let fields=fields; let changeField=changeField">
+    <ng-container *queryEntity="let rule; let entities=entities; let changeEntity=changeEntity">
+      <mat-form-field>
+        <mat-select [(ngModel)]="rule.entity" (ngModelChange)="changeEntity($event, rule)">
+          <mat-option *ngFor="let entity of entities" [value]="entity.name">
+          {{entity.description}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </ng-container>
+    <ng-container *queryField="let rule; let fields=fields; let changeField=changeField; let getFields = getFields">
       <mat-form-field>
         <mat-select [(ngModel)]="rule.field" (ngModelChange)="changeField($event, rule)">
-          <mat-option *ngFor="let field of fields" [value]="field.value">
+          <mat-option *ngFor="let field of getFields(rule.entity)" [value]="field.value">
             {{ field.name }}
           </mat-option>
         </mat-select>
@@ -162,6 +171,8 @@ export class AppComponent {
     operatorControlSize: 'col-auto px-0',
     fieldControl: 'form-control',
     fieldControlSize: 'col-auto',
+    entityControl: 'form-control',
+    entityControlSize: 'col-auto',
     inputControl: 'form-control',
     inputControlSize: 'col-auto'
   };
@@ -169,37 +180,39 @@ export class AppComponent {
   public query = {
     condition: 'and',
     rules: [
-      {field: 'age', operator: '<='},
-      {field: 'birthday', operator: '=', value: new Date()},
+      {field: 'age', operator: '<=', entity: 'Entity01'},
+      {field: 'birthday', operator: '=', value: new Date(), entity: 'Entity02'},
       {
         condition: 'or',
         rules: [
-          {field: 'gender', operator: '='},
-          {field: 'occupation', operator: 'in'},
-          {field: 'school', operator: 'is null'},
-          {field: 'notes', operator: '='}
+          {field: 'gender', operator: '=', entity: 'Entity01'},
+          {field: 'occupation', operator: 'in', entity: 'Entity02'},
+          {field: 'school', operator: 'is null', entity: 'Entity02'},
+          {field: 'notes', operator: '=', entity: 'Entity02'}
         ]
       }
     ]
   };
   public config: QueryBuilderConfig = {
+    entities: [{ name: 'Entity01', description: 'Entity 001' }, {name: 'Entity02', description: 'Entity 002'}],
     fields: {
-      age: {name: 'Age', type: 'number'},
+      age: {name: 'Age', type: 'number', entityName: 'Entity01'},
       gender: {
         name: 'Gender',
         type: 'category',
         options: [
           {name: 'Male', value: 'm'},
           {name: 'Female', value: 'f'}
-        ]
+        ],
+        entityName: 'Entity01'
       },
-      name: {name: 'Name', type: 'string'},
-      notes: {name: 'Notes', type: 'textarea', operators: ['=', '!=']},
+      name: {name: 'Name', type: 'string', entityName: 'Entity01'},
+      notes: {name: 'Notes', type: 'textarea', operators: ['=', '!='], entityName: 'Entity02'},
       educated: {name: 'College Degree?', type: 'boolean'},
       birthday: {name: 'Birthday', type: 'date', operators: ['=', '<=', '>'],
-        defaultValue: (() => new Date())
+        defaultValue: (() => new Date()), entityName: 'Entity02'
       },
-      school: {name: 'School', type: 'string', nullable: true},
+      school: {name: 'School', type: 'string', nullable: true, entityName: 'Entity02'},
       occupation: {
         name: 'Occupation',
         type: 'category',
@@ -208,7 +221,8 @@ export class AppComponent {
           {name: 'Teacher', value: 'teacher'},
           {name: 'Unemployed', value: 'unemployed'},
           {name: 'Scientist', value: 'scientist'}
-        ]
+        ],
+        entityName: 'Entity02'
       }
     }
   };

--- a/demo/umd/app/app.component.ts
+++ b/demo/umd/app/app.component.ts
@@ -1,3 +1,4 @@
+import { Entity } from './../../esm/lib/components/query-builder/query-builder.interfaces.d';
 import { Component } from '@angular/core';
 import { QueryBuilderConfig } from 'angular2-query-builder';
 
@@ -13,34 +14,36 @@ export class AppComponent {
   public query = {
     condition: 'and',
     rules: [
-      {field: 'age', operator: '<='},
-      {field: 'birthday', operator: '>='},
+      {field: 'age', operator: '<=' },
+      {field: 'birthday', operator: '>=', entity: 'Entity02'},
       {
         condition: 'or',
         rules: [
-          {field: 'gender', operator: '='},
-          {field: 'occupation', operator: 'in'},
-          {field: 'school', operator: 'is null'}
+          {field: 'gender', operator: '=', entity: 'Entity01'},
+          {field: 'occupation', operator: 'in', entity: 'Entity02'},
+          {field: 'school', operator: 'is null', entity: 'Entity02'}
         ]
       }
     ]
   };
   public config: QueryBuilderConfig = {
+    entities: [{ name: 'Entity01', description: 'Entity 01' }, {name: 'Entity02', description: 'Entity 02'}],
     fields: {
-      'age': {name: 'Age', type: 'number'},
-      'gender': {
+      age: {name: 'Age', type: 'number', entityName: 'Entity01'},
+      gender: {
         name: 'Gender',
         type: 'category',
         options: [
           {name: 'Male', value: 'm'},
           {name: 'Female', value: 'f'}
-        ]
+        ],
+        entityName: 'Entity01'
       },
-      'name': {name: 'Name', type: 'string'},
-      'educated': {name: 'College Degree?', type: 'boolean'},
-      'birthday': {name: 'Birthday', type: 'date'},
-      'school': {name: 'School', type: 'string', nullable: true},
-      'occupation': {
+      name: {name: 'Name', type: 'string', entityName: 'Entity01'},
+      educated: {name: 'College Degree?', type: 'boolean', entityName: 'Entity02'},
+      birthday: {name: 'Birthday', type: 'date', entityName: 'Entity02'},
+      school: {name: 'School', type: 'string', nullable: true, entityName: 'Entity02'},
+      occupation: {
         name: 'Occupation',
         type: 'string',
         options: [
@@ -48,8 +51,9 @@ export class AppComponent {
           {name: 'Teacher', value: 'teacher'},
           {name: 'Unemployed', value: 'unemployed'},
           {name: 'Scientist', value: 'scientist'}
-        ]
+        ],
+        entityName: 'Entity02'
       }
     }
-  }
+  };
 }

--- a/src/components/query-builder/index.ts
+++ b/src/components/query-builder/index.ts
@@ -1,6 +1,7 @@
 export * from './query-builder.component';
 export * from './query-builder.interfaces';
 export * from './query-button-group.directive';
+export * from './query-entity.directive';
 export * from './query-field.directive';
 export * from './query-input.directive';
 export * from './query-operator.directive';

--- a/src/components/query-builder/query-builder.component.html
+++ b/src/components/query-builder/query-builder.component.html
@@ -59,6 +59,21 @@
             </div>
           </ng-template>
 
+          <div *ngIf="entities?.length > 0" class="q-inline-block-display" >
+            <ng-container *ngIf="getEntityTemplate() as template; else defaultEntity">
+              <ng-container *ngTemplateOutlet="template; context: getEntityContext(rule)"></ng-container>
+            </ng-container>
+        </div>
+        <ng-template #defaultEntity>
+          <div [ngClass]="getClassNames('entityControlSize')">
+            <select [ngClass]="getClassNames('entityControl')" [(ngModel)]="rule.entity" (ngModelChange)="changeEntity($event, rule)">
+              <option *ngFor="let entity of entities" [ngValue]="entity.name">
+                {{entity.description}}
+              </option>
+            </select>
+         </div>
+        </ng-template>
+
           <ng-container *ngIf="getFieldTemplate() as template; else defaultField">
             <ng-container *ngTemplateOutlet="template; context: getFieldContext(rule)"></ng-container>
           </ng-container>
@@ -66,7 +81,7 @@
           <ng-template #defaultField>
             <div [ngClass]="getClassNames('fieldControlSize')">
               <select [ngClass]="getClassNames('fieldControl')" [(ngModel)]="rule.field" (ngModelChange)="changeField($event, rule)">
-                <option *ngFor="let field of fields" [ngValue]="field.value">
+                <option *ngFor="let field of getFields(rule.entity)" [ngValue]="field.value">
                   {{field.name}}
                 </option>
               </select>
@@ -120,6 +135,7 @@
           [parentInputTemplates]="parentInputTemplates || inputTemplates"
           [parentOperatorTemplate]="parentOperatorTemplate || operatorTemplate"
           [parentFieldTemplate]="parentFieldTemplate || fieldTemplate"
+          [parentEntityTemplate]="parentEntityTemplate || entityTemplate"
           [parentSwitchGroupTemplate]="parentSwitchGroupTemplate || switchGroupTemplate"
           [parentButtonGroupTemplate]="parentButtonGroupTemplate || buttonGroupTemplate"
           [parentRemoveButtonTemplate]="parentRemoveButtonTemplate || removeButtonTemplate"

--- a/src/components/query-builder/query-builder.component.scss
+++ b/src/components/query-builder/query-builder.component.scss
@@ -43,7 +43,7 @@
     vertical-align: top;
   }
 
-  .q-input-control, .q-operator-control, .q-field-control {
+  .q-input-control, .q-operator-control, .q-field-control, .q-entity-control {
     display: inline-block;
     padding: 5px 8px;
     color: #555;
@@ -55,7 +55,7 @@
     width: auto;
   }
 
-  .q-operator-control, .q-field-control, .q-input-control:not([type='checkbox']) {
+  .q-operator-control, .q-field-control,.q-entity-control, .q-input-control:not([type='checkbox']) {
     min-height: 32px;
     -webkit-appearance: none;
   }
@@ -166,5 +166,10 @@
     &:last-child::after {
       content: none;
     }
+  }
+
+  .q-inline-block-display{
+    display: inline-block;
+    vertical-align: top;
   }
 }

--- a/src/components/query-builder/query-builder.interfaces.ts
+++ b/src/components/query-builder/query-builder.interfaces.ts
@@ -9,6 +9,7 @@ export interface Rule {
   field: string;
   value?: any;
   operator?: string;
+  entity?: string;
 }
 
 export interface Option {
@@ -29,12 +30,22 @@ export interface Field {
   operators?: string[];
   defaultValue?: any;
   defaultOperator?: any;
+  entityName?: string;
   validator?: (rule: Rule, parent: RuleSet) => any | null;
 }
 
 export interface LocalRuleMeta {
   ruleset: boolean;
   invalid: boolean;
+}
+
+export interface EntityMap {
+  entities: Entity[];
+}
+
+export interface Entity {
+  name: string;
+  description: string;
 }
 
 export interface QueryBuilderClassNames {
@@ -60,6 +71,8 @@ export interface QueryBuilderClassNames {
   emptyWarning?: string;
   fieldControl?: string;
   fieldControlSize?: string;
+  entityControl?: string;
+  entityControlSize?: string;
   operatorControl?: string;
   operatorControlSize?: string;
   inputControl?: string;
@@ -68,6 +81,7 @@ export interface QueryBuilderClassNames {
 
 export interface QueryBuilderConfig {
   fields: FieldMap;
+  entities?: Entity[];
   allowEmptyRulesets?: boolean;
   getOperators?: (fieldName: string, field: Field) => string[];
   getInputType?: (field: string, operator: string) => string;
@@ -83,8 +97,15 @@ export interface OperatorContext {
   $implicit: Rule;
 }
 
+export interface EntityContext {
+  changeEntity: (entityName: string, rule: Rule) => void;
+  entities: Entity[];
+  $implicit: Rule;
+}
+
 export interface FieldContext {
   changeField: (fieldName: string, rule: Rule) => void;
+  getFields: (entityName: string) => void;
   fields: Field[];
   $implicit: Rule;
 }

--- a/src/components/query-builder/query-entity.directive.ts
+++ b/src/components/query-builder/query-entity.directive.ts
@@ -1,0 +1,6 @@
+import { Directive, Input, TemplateRef } from '@angular/core';
+
+@Directive({selector: '[queryEntity]'})
+export class QueryEntityDirective {
+  constructor(public template: TemplateRef<any>) {}
+}

--- a/src/query-builder.module.ts
+++ b/src/query-builder.module.ts
@@ -5,6 +5,7 @@ import {
     QueryBuilderComponent,
     QueryInputDirective,
     QueryFieldDirective,
+    QueryEntityDirective,
     QueryOperatorDirective,
     QueryButtonGroupDirective,
     QuerySwitchGroupDirective,
@@ -21,6 +22,7 @@ import {
     QueryInputDirective,
     QueryOperatorDirective,
     QueryFieldDirective,
+    QueryEntityDirective,
     QueryButtonGroupDirective,
     QuerySwitchGroupDirective,
     QueryRemoveButtonDirective
@@ -30,6 +32,7 @@ import {
     QueryInputDirective,
     QueryOperatorDirective,
     QueryFieldDirective,
+    QueryEntityDirective,
     QueryButtonGroupDirective,
     QuerySwitchGroupDirective,
     QueryRemoveButtonDirective


### PR DESCRIPTION
**Overview:**
This change add feature to query builder by providing grouping concepts to the configuration fields. Basically this feature groups list of fields into one group name(entity) and provide option to the user to view/select the fields based on group name filter. It gives better user experience when large # of fields are used in configuration. By default this feature is disabled. This feature can be enabled by passing additional information in QueryBuilderConfig, which does not alter existing schema. This change applied on top of latest commit 0.2.5.
**UI Change:**
While creating rule, users are provided option to choose the group(entity) and based on group selection, corresponding fields will be populated for query creation.
**Description:**
Added new directive “QueryEntityDirective” to builder module to display list of group names associated to fields. QueryBuilderConfig has new property ‘entities’ to define the distinct list of entities/groups(name, description). Each field has additional metadata information called entityName(group name) and it is associated to entity/group(defined in ‘entities’). Both ‘entities’ property of QueryBuilderConfig and ‘entityname’ property of fields are optional. If these properties are removed, module will work as today without any issue. Rules generated from query section include ‘entity’ metadata information for reference.
**Additional Information:**
queryEntity:
• changeEntity – function to handle changes in entity list
• entities – list of entities(group) mention in config
• $implicit – Current rule object which contains the field, value and operator
queryField:
• getFields – function to get list of fields associated to entity(group)
Example:
{
entities: [{ name: 'personal', description: 'Personal Details' }, { name: 'education', description: 'Education'}, { name: 'professional', description: 'Professional'}],
fields: {
age: {name: 'Age', type: 'number', entityName: 'personal'},
name: {name: 'Name', type: 'string', entityName: 'personal'},
birthday: {name: 'Birthday', type: 'date', entityName: 'personal'},
educated: {name: 'College Degree?', type: 'boolean', entityName: 'education'},
school: {name: 'School', type: 'string', nullable: true, entityName: 'education'},
occupation: {
name: 'Occupation',
type: 'string',
options: [
{name: 'Student', value: 'student'},
{name: 'Teacher', value: 'teacher'},
{name: 'Unemployed', value: 'unemployed'},
{name: 'Scientist', value: 'scientist'}
],
entityName: 'professional'
},
salary: {name: 'Salary', type: 'number', entityName: 'professional'},
}
**ToDo:**
Update documentation and ReadMe file
**Steps to Test:**
1.	Update configuration section to enable this feature as mention above i.e Add array of ‘entities’ to QueryBuilderConfig and add associate fields with one of the entity name.
2.	Try adding new Rule in Query builder UI. Additional drop down will be displayed before fields drop down and it will list entities descriptions.
3.	Changing the entity from drop down will update the list of fields for rule creation
4.	Created query will have additional metadata property appended to each Rule
Example:
"rules": [
{
"field": "occupation",
"operator": "=",
"entity": "professional"
}
**Status:**
Development Completed

