### PR TITLE
specify the type attribute for the <button> elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ Example of how you can completely customize the query component with another lib
 ```html
 <query-builder [(ngModel)]='query' [config]='config'>
   <ng-container *queryButtonGroup="let ruleset; let addRule=addRule; let addRuleSet=addRuleSet; let removeRuleSet=removeRuleSet">
-    <button mat-button (click)="addRule()">+ Rule</button>
-    <button mat-button (click)="addRuleSet()">+ Ruleset</button>
-    <button mat-button (click)="removeRuleSet()">- Ruleset</button>
+    <button type="button" mat-button (click)="addRule()">+ Rule</button>
+    <button type="button" mat-button (click)="addRuleSet()">+ Ruleset</button>
+    <button type="button" mat-button (click)="removeRuleSet()">- Ruleset</button>
   </ng-container>
   <ng-container *queryRemoveButton="let rule; let removeRule=removeRule">
-    <button mat-icon-button color="accent" (click)="removeRule(rule)">
+    <button type="button" mat-icon-button color="accent" (click)="removeRule(rule)">
       <mat-icon>remove</mat-icon>
     </button>
   </ng-container>

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -43,18 +43,18 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from '../../lib';
   <mat-card>
   <query-builder [(ngModel)]='query' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse'>
     <ng-container *queryButtonGroup="let ruleset; let addRule=addRule; let addRuleSet=addRuleSet; let removeRuleSet=removeRuleSet">
-      <button mat-icon-button color="primary" (click)="addRule()">
+      <button type="button" mat-icon-button color="primary" (click)="addRule()">
         <mat-icon>add</mat-icon></button>
-      <button mat-icon-button color="primary" *ngIf="addRuleSet" (click)="addRuleSet()">
+      <button type="button" mat-icon-button color="primary" *ngIf="addRuleSet" (click)="addRuleSet()">
         <mat-icon>add_circle_outline</mat-icon></button>
-      <button mat-icon-button color="accent" *ngIf="removeRuleSet" (click)="removeRuleSet()">
+      <button type="button" mat-icon-button color="accent" *ngIf="removeRuleSet" (click)="removeRuleSet()">
         <mat-icon>remove_circle_outline</mat-icon></button>
     </ng-container>
     <ng-container *queryArrowIcon>
       <mat-icon ngClass="mat-arrow-icon">chevron_right</mat-icon>
     </ng-container>
     <ng-container *queryRemoveButton="let rule; let removeRule=removeRule">
-      <button mat-icon-button color="accent" (click)="removeRule(rule)">
+      <button type="button" mat-icon-button color="accent" (click)="removeRule(rule)">
         <mat-icon>remove</mat-icon>
       </button>
     </ng-container>

--- a/src/components/query-builder/query-builder.component.html
+++ b/src/components/query-builder/query-builder.component.html
@@ -17,14 +17,14 @@
 
   <ng-template #defaultButtonGroup>
     <div [ngClass]="getClassNames('buttonGroup', 'rightAlign')">
-      <button (click)="addRule()" [ngClass]="getClassNames('button')" [disabled]=disabled>
+      <button type="button" (click)="addRule()" [ngClass]="getClassNames('button')" [disabled]=disabled>
         <i [ngClass]="getClassNames('addIcon')"></i> Rule
       </button>
-      <button (click)="addRuleSet()" [ngClass]="getClassNames('button')" *ngIf="allowRuleset" [disabled]=disabled>
+      <button type="button" (click)="addRuleSet()" [ngClass]="getClassNames('button')" *ngIf="allowRuleset" [disabled]=disabled>
         <i [ngClass]="getClassNames('addIcon')"></i> Ruleset
       </button>
       <ng-container *ngIf="!!parentValue && allowRuleset">
-        <button (click)="removeRuleSet()" [ngClass]="getClassNames('button', 'removeButton')" [disabled]=disabled>
+        <button type="button" (click)="removeRuleSet()" [ngClass]="getClassNames('button', 'removeButton')" [disabled]=disabled>
           <i [ngClass]="getClassNames('removeIcon')"></i>
         </button>
       </ng-container>
@@ -66,7 +66,7 @@
 
             <ng-template #defaultRemoveButton>
               <div [ngClass]="getClassNames('removeButtonSize', 'rightAlign')">
-                <button [ngClass]="getClassNames('button', 'removeButton')" (click)="removeRule(rule, data)" [disabled]=disabled>
+                <button type="button" [ngClass]="getClassNames('button', 'removeButton')" (click)="removeRule(rule, data)" [disabled]=disabled>
                   <i [ngClass]="getClassNames('removeIcon')"></i>
                 </button>
               </div>


### PR DESCRIPTION
The type attribute of `<button>` element should always be specified. When the type attribute is missing, the button behaves as a submit button.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type