### PR TITLE
Add flag to @ViewChild and @ContentChild queries for Angular v8 compatibility

### DIFF
--- a/src/components/query-builder/query-builder.component.ts
+++ b/src/components/query-builder/query-builder.component.ts
@@ -138,7 +138,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   @Input() parentChangeCallback: () => void;
   @Input() parentTouchedCallback: () => void;
 
-  @ViewChild('treeContainer') treeContainer: ElementRef;
+  @ViewChild('treeContainer', {static: true}) treeContainer: ElementRef;
 
   @ContentChild(QueryButtonGroupDirective) buttonGroupTemplate: QueryButtonGroupDirective;
   @ContentChild(QuerySwitchGroupDirective) switchGroupTemplate: QuerySwitchGroupDirective;

--- a/src/components/query-builder/query-builder.component.ts
+++ b/src/components/query-builder/query-builder.component.ts
@@ -140,15 +140,15 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
 
   @ViewChild('treeContainer', {static: true}) treeContainer: ElementRef;
 
-  @ContentChild(QueryButtonGroupDirective) buttonGroupTemplate: QueryButtonGroupDirective;
-  @ContentChild(QuerySwitchGroupDirective) switchGroupTemplate: QuerySwitchGroupDirective;
-  @ContentChild(QueryFieldDirective) fieldTemplate: QueryFieldDirective;
-  @ContentChild(QueryEntityDirective) entityTemplate: QueryEntityDirective;
-  @ContentChild(QueryOperatorDirective) operatorTemplate: QueryOperatorDirective;
-  @ContentChild(QueryRemoveButtonDirective) removeButtonTemplate: QueryRemoveButtonDirective;
-  @ContentChild(QueryEmptyWarningDirective) emptyWarningTemplate: QueryEmptyWarningDirective;
+  @ContentChild(QueryButtonGroupDirective, {static: false}) buttonGroupTemplate: QueryButtonGroupDirective;
+  @ContentChild(QuerySwitchGroupDirective, {static: false}) switchGroupTemplate: QuerySwitchGroupDirective;
+  @ContentChild(QueryFieldDirective, {static: false}) fieldTemplate: QueryFieldDirective;
+  @ContentChild(QueryEntityDirective, {static: false}) entityTemplate: QueryEntityDirective;
+  @ContentChild(QueryOperatorDirective, {static: false}) operatorTemplate: QueryOperatorDirective;
+  @ContentChild(QueryRemoveButtonDirective, {static: false}) removeButtonTemplate: QueryRemoveButtonDirective;
+  @ContentChild(QueryEmptyWarningDirective, {static: false}) emptyWarningTemplate: QueryEmptyWarningDirective;
   @ContentChildren(QueryInputDirective) inputTemplates: QueryList<QueryInputDirective>;
-  @ContentChild(QueryArrowIconDirective) arrowIconTemplate: QueryArrowIconDirective;
+  @ContentChild(QueryArrowIconDirective, {static: false}) arrowIconTemplate: QueryArrowIconDirective;
 
   private defaultTemplateTypes: string[] = [
     'string', 'number', 'time', 'date', 'category', 'boolean', 'multiselect'];


### PR DESCRIPTION
In Angular v8, the `static` flag is required on `@ViewChild` queries. This change adds the flag for v8 compatibility. 

Note that v7 apps will still work with these v8 flags. See [explanation here](https://github.com/angular/angular/issues/30654#issuecomment-495642339).

For more info, see the guide here: https://angular.io/guide/static-query-migration.