### PR TITLE
Not to reset the field value.

### DIFF
--- a/src/components/query-builder/query-builder.component.ts
+++ b/src/components/query-builder/query-builder.component.ts
@@ -525,7 +525,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     if (field && field.defaultValue !== undefined) {
       rule.value = this.getDefaultValue(field.defaultValue);
     } else {
-      delete rule.value;
+      //delete rule.value;
     }
 
     rule.operator = this.getDefaultOperator(field);


### PR DESCRIPTION
In query builder when i changed the dropdown list then automatically changed the value field. 
I have one requirement , when i change the dropdown list then value should not change. keep it as it is.