### PR TITLE
Added isChild property to RuleSet interface

### DIFF
--- a/src/components/query-builder/query-builder.interfaces.ts
+++ b/src/components/query-builder/query-builder.interfaces.ts
@@ -4,6 +4,7 @@ export interface RuleSet {
   condition: string;
   rules: Array<RuleSet | Rule>;
   collapsed?: boolean;
+  isChild?: boolean;
 }
 
 export interface Rule {


### PR DESCRIPTION
Currently it's not possible to check if a RuleSet is a nested RuleSet. This would be useful when overriding the addRule and addRuleSet functions. For my use case I need to disable the option to make a new RuleSet in an added RuleSet. Maybe this change will be useful for other users as well.

For example,

```typescript
this.config{
 fields: this.fields,
 addRuleSet() : (parent) => {
        if(parent.isChild){
           //handle if the parent is a nested/child RuleSet.
           //For example, show an error message.
        }else {
           //create new RuleSet with property isChild = true.
        }
    }
}

```

