### PR TITLE
Fix pathing issue with typings of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-query-builder",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A modernized Angular 2+ query builder based on jquery QueryBuilder",
   "main": "./dist/angular2-query-builder/bundles/angular2-query-builder.umd.js",
   "module": "./dist/angular2-query-builder/esm5/angular2-query-builder.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modernized Angular 2+ query builder based on jquery QueryBuilder",
   "main": "./dist/angular2-query-builder/bundles/angular2-query-builder.umd.js",
   "module": "./dist/angular2-query-builder/esm5/angular2-query-builder.js",
-  "typings": "./dist/angular2-query-builder.d.ts",
+  "typings": "./dist/angular2-query-builder/angular2-query-builder.d.ts",
   "license": "MIT",
   "private": false,
   "keywords": [


### PR DESCRIPTION
Fix pathing issue with typings file. Causes "Could not find a declaration file for module 'angular2-query-builder'." when "noImplicitAny": true in tsconfig.json