### PR TITLE
Allow options to be built as label/value objects

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -90,7 +90,7 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from 'angular2-query-build
       <mat-form-field [style.width.px]="90">
         <mat-select [(ngModel)]="rule.operator" (ngModelChange)="onChange(rule)">
           <mat-option *ngFor="let operator of operators" [value]="operator.value">
-            {{ operator.label }}
+            {{ operator.name }}
           </mat-option>
         </mat-select>
       </mat-form-field>

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -89,8 +89,8 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from 'angular2-query-build
     <ng-container *queryOperator="let rule; let operators=operators; let onChange=onChange">
       <mat-form-field [style.width.px]="90">
         <mat-select [(ngModel)]="rule.operator" (ngModelChange)="onChange(rule)">
-          <mat-option *ngFor="let value of operators" [value]="value">
-            {{ value }}
+          <mat-option *ngFor="let operator of operators" [value]="operator.value">
+            {{ operator.label }}
           </mat-option>
         </mat-select>
       </mat-form-field>

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
@@ -113,8 +113,8 @@
               <div [ngClass]="getClassNames('operatorControlSize')">
                 <select [ngClass]="getClassNames('operatorControl')" [(ngModel)]="rule.operator" (ngModelChange)="changeOperator(rule)"
                   [disabled]="disabled">
-                  <option *ngFor="let operator of getOperators(rule.field)" [ngValue]="operator">
-                    {{operator}}
+                  <option *ngFor="let operator of getOperators(rule.field)" [ngValue]="operator.value">
+                    {{operator.label}}
                   </option>
                 </select>
               </div>

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
@@ -114,7 +114,7 @@
                 <select [ngClass]="getClassNames('operatorControl')" [(ngModel)]="rule.operator" (ngModelChange)="changeOperator(rule)"
                   [disabled]="disabled">
                   <option *ngFor="let operator of getOperators(rule.field)" [ngValue]="operator.value">
-                    {{operator.label}}
+                    {{operator.name}}
                   </option>
                 </select>
               </div>

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
@@ -103,13 +103,44 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     inputControl: 'q-input-control',
     inputControlSize: 'q-control-size'
   };
-  public defaultOperatorMap: { [key: string]: string[] } = {
-    string: ['=', '!=', 'contains', 'like'],
-    number: ['=', '!=', '>', '>=', '<', '<='],
-    time: ['=', '!=', '>', '>=', '<', '<='],
-    date: ['=', '!=', '>', '>=', '<', '<='],
-    category: ['=', '!=', 'in', 'not in'],
-    boolean: ['=']
+  public defaultOperatorMap: { [key: string]: Array<{ value: string, label: string }> } = {
+    string: [
+      { value: '=', label: '=' },
+      { value: '!=', label: '!=' },
+      { value: 'contains', label: 'contains' },
+      { value: 'like', label: 'like' }
+    ],
+    number: [
+      { value: '=', label: '=' },
+      { value: '!=', label: '!=' },
+      { value: '>', label: '>' },
+      { value: '>=', label: '>=' },
+      { value: '<', label: '<' },
+      { value: '<=', label: '<=' }
+    ],
+    time: [
+      { value: '=', label: '=' },
+      { value: '!=', label: '!=' },
+      { value: '>', label: '>' },
+      { value: '>=', label: '>=' },
+      { value: '<', label: '<' },
+      { value: '<=', label: '<=' }
+    ],
+    date: [
+      { value: '=', label: '=' },
+      { value: '!=', label: '!=' },
+      { value: '>', label: '>' },
+      { value: '>=', label: '>=' },
+      { value: '<', label: '<' },
+      { value: '<=', label: '<=' }
+    ],
+    category: [
+      { value: '=', label: '=' },
+      { value: '!=', label: '!=' },
+      { value: 'in', label: 'in' },
+      { value: 'not in', label: 'not in' }
+    ],
+    boolean: [ { value: '=', label: '=' } ]
   };
   @Input() disabled: boolean;
   @Input() data: RuleSet = { condition: 'and', rules: [] };
@@ -155,7 +186,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   private defaultPersistValueTypes: string[] = [
     'string', 'number', 'time', 'date', 'boolean'];
   private defaultEmptyList: any[] = [];
-  private operatorsCache: { [key: string]: string[] };
+  private operatorsCache: { [key: string]: Array<{ value: string, label: string }> };
   private inputContextCache = new Map<Rule, InputContext>();
   private operatorContextCache = new Map<Rule, OperatorContext>();
   private fieldContextCache = new Map<Rule, FieldContext>();
@@ -167,7 +198,21 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
 
   // ----------OnInit Implementation----------
 
-  ngOnInit() { }
+  ngOnInit() {
+    // Loop through all the fields and change the operators to value/label if they are just string arrays
+    for (const field in this.config.fields) {
+      if (this.config.fields[field].operators) {
+        this.config.fields[field].operators = (this.config.fields[field].operators as any[])
+        .map((operator: string | { value: string, label: string}) => {
+          if (typeof(operator) === 'string') {
+            return { value: operator, label: operator };
+          }
+
+          return operator;
+        });
+      }
+    }
+  }
 
   // ----------OnChanges Implementation----------
 
@@ -249,7 +294,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   }
 
   findTemplateForRule(rule: Rule): TemplateRef<any> {
-    const type = this.getInputType(rule.field, rule.operator);
+    const type = this.getInputType(rule.field, rule.operator.value);
     if (type) {
       const queryInput = this.findQueryInput(type);
       if (queryInput) {
@@ -268,7 +313,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     return templates.find((item) => item.queryInputType === type);
   }
 
-  getOperators(field: string): string[] {
+  getOperators(field: string): Array<{ value: string, label: string }> {
     if (this.operatorsCache[field]) {
       return this.operatorsCache[field];
     }
@@ -291,7 +336,10 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
           `Please define an 'operators' property on the field or use the 'operatorMap' binding to fix this.`);
       }
       if (fieldObject.nullable) {
-        operators = operators.concat(['is null', 'is not null']);
+        operators = operators.concat([
+          { value: 'is null', label: 'is null' },
+          { value: 'is not null', label: 'is not null' }
+        ]);
       }
     } else {
       console.warn(`No 'type' property found on field: '${field}'`);
@@ -366,7 +414,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     }
   }
 
-  getDefaultOperator(field: Field): string {
+  getDefaultOperator(field: Field): { value: string, label: string } {
     if (field && field.defaultOperator !== undefined) {
       return this.getDefaultValue(field.defaultOperator);
     } else {
@@ -491,9 +539,9 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     }
 
     if (this.config.coerceValueForOperator) {
-      rule.value = this.config.coerceValueForOperator(rule.operator, rule.value, rule);
+      rule.value = this.config.coerceValueForOperator(rule.operator.value, rule.value, rule);
     } else {
-      rule.value = this.coerceValueForOperator(rule.operator, rule.value, rule);
+      rule.value = this.coerceValueForOperator(rule.operator.value, rule.value, rule);
     }
 
     this.handleTouched();

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
@@ -103,44 +103,44 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     inputControl: 'q-input-control',
     inputControlSize: 'q-control-size'
   };
-  public defaultOperatorMap: { [key: string]: Array<{ value: string, label: string }> } = {
+  public defaultOperatorMap: { [key: string]: Array<{ value: string, name: string }> } = {
     string: [
-      { value: '=', label: '=' },
-      { value: '!=', label: '!=' },
-      { value: 'contains', label: 'contains' },
-      { value: 'like', label: 'like' }
+      { value: '=', name: '=' },
+      { value: '!=', name: '!=' },
+      { value: 'contains', name: 'contains' },
+      { value: 'like', name: 'like' }
     ],
     number: [
-      { value: '=', label: '=' },
-      { value: '!=', label: '!=' },
-      { value: '>', label: '>' },
-      { value: '>=', label: '>=' },
-      { value: '<', label: '<' },
-      { value: '<=', label: '<=' }
+      { value: '=', name: '=' },
+      { value: '!=', name: '!=' },
+      { value: '>', name: '>' },
+      { value: '>=', name: '>=' },
+      { value: '<', name: '<' },
+      { value: '<=', name: '<=' }
     ],
     time: [
-      { value: '=', label: '=' },
-      { value: '!=', label: '!=' },
-      { value: '>', label: '>' },
-      { value: '>=', label: '>=' },
-      { value: '<', label: '<' },
-      { value: '<=', label: '<=' }
+      { value: '=', name: '=' },
+      { value: '!=', name: '!=' },
+      { value: '>', name: '>' },
+      { value: '>=', name: '>=' },
+      { value: '<', name: '<' },
+      { value: '<=', name: '<=' }
     ],
     date: [
-      { value: '=', label: '=' },
-      { value: '!=', label: '!=' },
-      { value: '>', label: '>' },
-      { value: '>=', label: '>=' },
-      { value: '<', label: '<' },
-      { value: '<=', label: '<=' }
+      { value: '=', name: '=' },
+      { value: '!=', name: '!=' },
+      { value: '>', name: '>' },
+      { value: '>=', name: '>=' },
+      { value: '<', name: '<' },
+      { value: '<=', name: '<=' }
     ],
     category: [
-      { value: '=', label: '=' },
-      { value: '!=', label: '!=' },
-      { value: 'in', label: 'in' },
-      { value: 'not in', label: 'not in' }
+      { value: '=', name: '=' },
+      { value: '!=', name: '!=' },
+      { value: 'in', name: 'in' },
+      { value: 'not in', name: 'not in' }
     ],
-    boolean: [ { value: '=', label: '=' } ]
+    boolean: [ { value: '=', name: '=' } ]
   };
   @Input() disabled: boolean;
   @Input() data: RuleSet = { condition: 'and', rules: [] };
@@ -186,7 +186,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   private defaultPersistValueTypes: string[] = [
     'string', 'number', 'time', 'date', 'boolean'];
   private defaultEmptyList: any[] = [];
-  private operatorsCache: { [key: string]: Array<{ value: string, label: string }> };
+  private operatorsCache: { [key: string]: Array<{ value: string, name: string }> };
   private inputContextCache = new Map<Rule, InputContext>();
   private operatorContextCache = new Map<Rule, OperatorContext>();
   private fieldContextCache = new Map<Rule, FieldContext>();
@@ -203,9 +203,9 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     for (const field in this.config.fields) {
       if (this.config.fields[field].operators) {
         this.config.fields[field].operators = (this.config.fields[field].operators as any[])
-        .map((operator: string | { value: string, label: string}) => {
+        .map((operator: string | { value: string, name: string}) => {
           if (typeof(operator) === 'string') {
-            return { value: operator, label: operator };
+            return { value: operator, name: operator };
           }
 
           return operator;
@@ -313,7 +313,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     return templates.find((item) => item.queryInputType === type);
   }
 
-  getOperators(field: string): Array<{ value: string, label: string }> {
+  getOperators(field: string): Array<{ value: string, name: string }> {
     if (this.operatorsCache[field]) {
       return this.operatorsCache[field];
     }
@@ -337,8 +337,8 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
       }
       if (fieldObject.nullable) {
         operators = operators.concat([
-          { value: 'is null', label: 'is null' },
-          { value: 'is not null', label: 'is not null' }
+          { value: 'is null', name: 'is null' },
+          { value: 'is not null', name: 'is not null' }
         ]);
       }
     } else {
@@ -414,7 +414,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     }
   }
 
-  getDefaultOperator(field: Field): { value: string, label: string } {
+  getDefaultOperator(field: Field): { value: string, name: string } {
     if (field && field.defaultOperator !== undefined) {
       return this.getDefaultValue(field.defaultOperator);
     } else {

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
@@ -10,7 +10,7 @@ export interface RuleSet {
 export interface Rule {
   field: string;
   value?: any;
-  operator?: string;
+  operator?: { value: string, label: string };
   entity?: string;
 }
 
@@ -29,7 +29,7 @@ export interface Field {
   type: string;
   nullable?: boolean;
   options?: Option[];
-  operators?: string[];
+  operators?: string[] | Array<{ value: string, label: string }>;
   defaultValue?: any;
   defaultOperator?: any;
   entity?: string;
@@ -90,7 +90,7 @@ export interface QueryBuilderConfig {
   fields: FieldMap;
   entities?: EntityMap;
   allowEmptyRulesets?: boolean;
-  getOperators?: (fieldName: string, field: Field) => string[];
+  getOperators?: (fieldName: string, field: Field) => Array<{ value: string, label: string }>;
   getInputType?: (field: string, operator: string) => string;
   getOptions?: (field: string) => Option[];
   addRuleSet?: (parent: RuleSet) => void;
@@ -138,7 +138,7 @@ export interface FieldContext {
 export interface OperatorContext {
   onChange: () => void;
   getDisabledState: () => boolean;
-  operators: string[];
+  operators: Array<{ value: string, label: string }>;
   $implicit: Rule;
 }
 

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
@@ -10,7 +10,7 @@ export interface RuleSet {
 export interface Rule {
   field: string;
   value?: any;
-  operator?: { value: string, label: string };
+  operator?: { value: string, name: string };
   entity?: string;
 }
 
@@ -29,7 +29,7 @@ export interface Field {
   type: string;
   nullable?: boolean;
   options?: Option[];
-  operators?: string[] | Array<{ value: string, label: string }>;
+  operators?: string[] | Array<{ value: string, name: string }>;
   defaultValue?: any;
   defaultOperator?: any;
   entity?: string;
@@ -90,7 +90,7 @@ export interface QueryBuilderConfig {
   fields: FieldMap;
   entities?: EntityMap;
   allowEmptyRulesets?: boolean;
-  getOperators?: (fieldName: string, field: Field) => Array<{ value: string, label: string }>;
+  getOperators?: (fieldName: string, field: Field) => Array<{ value: string, name: string }>;
   getInputType?: (field: string, operator: string) => string;
   getOptions?: (field: string) => Option[];
   addRuleSet?: (parent: RuleSet) => void;
@@ -138,7 +138,7 @@ export interface FieldContext {
 export interface OperatorContext {
   onChange: () => void;
   getDisabledState: () => boolean;
-  operators: Array<{ value: string, label: string }>;
+  operators: Array<{ value: string, name: string }>;
   $implicit: Rule;
 }
 


### PR DESCRIPTION
Add the ability to pass operator options as value/labels objects.

I think this works for all use cases. I made sure the demo continues to work but there are no tests so I could be missing something.

resolves #146