### PR TITLE
Add custom rendering functions

### DIFF
--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
@@ -3,176 +3,361 @@
     <i [ngClass]="getClassNames('arrowIcon')"></i>
   </ng-template>
 
-  <a *ngIf="allowCollapse" (click)="toggleCollapse()" [ngClass]="getClassNames('arrowIconButton', data.collapsed ? 'collapsed' : null)">
-    <ng-container *ngIf="getArrowIconTemplate() as template; else defaultArrowIcon">
-      <ng-container *ngTemplateOutlet="template; context: getArrowIconContext()"></ng-container>
+  <a
+    *ngIf="allowCollapse"
+    (click)="toggleCollapse()"
+    [ngClass]="
+      getClassNames('arrowIconButton', data.collapsed ? 'collapsed' : null)
+    "
+  >
+    <ng-container
+      *ngIf="getArrowIconTemplate() as template; else defaultArrowIcon"
+    >
+      <ng-container
+        *ngTemplateOutlet="template; context: getArrowIconContext()"
+      ></ng-container>
     </ng-container>
   </a>
 
-  <ng-container *ngIf="getButtonGroupTemplate() as template; else defaultButtonGroup">
+  <ng-container
+    *ngIf="getButtonGroupTemplate() as template; else defaultButtonGroup"
+  >
     <div [ngClass]="getClassNames('buttonGroup', 'rightAlign')">
-      <ng-container *ngTemplateOutlet="template; context: getButtonGroupContext()"></ng-container>
+      <ng-container
+        *ngTemplateOutlet="template; context: getButtonGroupContext()"
+      ></ng-container>
     </div>
   </ng-container>
 
   <ng-template #defaultButtonGroup>
     <div [ngClass]="getClassNames('buttonGroup', 'rightAlign')">
-      <button type="button" (click)="addRule()" [ngClass]="getClassNames('button')" [disabled]=disabled>
+      <button
+        type="button"
+        (click)="addRule()"
+        [ngClass]="getClassNames('button')"
+        [disabled]="addRuleDisabled(data) && disabled"
+      >
         <i [ngClass]="getClassNames('addIcon')"></i> Rule
       </button>
-      <button type="button" (click)="addRuleSet()" [ngClass]="getClassNames('button')" *ngIf="allowRuleset" [disabled]=disabled>
+      <button
+        type="button"
+        (click)="addRuleSet()"
+        [ngClass]="getClassNames('button')"
+        *ngIf="allowRuleset"
+        [disabled]="addRuleSetDisabled(data) && disabled"
+      >
         <i [ngClass]="getClassNames('addIcon')"></i> Ruleset
       </button>
       <ng-container *ngIf="!!parentValue && allowRuleset">
-        <button type="button" (click)="removeRuleSet()" [ngClass]="getClassNames('button', 'removeButton')" [disabled]=disabled>
+        <button
+          type="button"
+          (click)="removeRuleSet()"
+          [ngClass]="getClassNames('button', 'removeButton')"
+          [disabled]="removeRuleSetDisabled(data) && disabled"
+        >
           <i [ngClass]="getClassNames('removeIcon')"></i>
         </button>
       </ng-container>
     </div>
   </ng-template>
 
-  <ng-container *ngIf="getSwitchGroupTemplate() as template; else defaultSwitchGroup">
-    <ng-container *ngTemplateOutlet="template; context: getSwitchGroupContext()"></ng-container>
+  <ng-container
+    *ngIf="getSwitchGroupTemplate() as template; else defaultSwitchGroup"
+  >
+    <ng-container
+      *ngTemplateOutlet="template; context: getSwitchGroupContext()"
+    ></ng-container>
   </ng-container>
 
   <ng-template #defaultSwitchGroup>
     <div [ngClass]="getClassNames('switchGroup', 'transition')" *ngIf="data">
-      <div [ngClass]="getClassNames('switchControl')">
-        <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
-          value="and" #andOption />
-        <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">AND</label>
-      </div>
-      <div [ngClass]="getClassNames('switchControl')">
-        <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
-          value="or" #orOption />
-        <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">OR</label>
+      <div
+        [ngClass]="getClassNames('switchControl')"
+        *ngFor="let condition of getConditions(data)"
+      >
+        <input
+          type="radio"
+          [ngClass]="getClassNames('switchRadio')"
+          [(ngModel)]="data.condition"
+          [disabled]="disabled"
+          [value]="condition"
+        />
+        <label
+          (click)="changeCondition(condition, data)"
+          [ngClass]="getClassNames('switchLabel')"
+          >{{ condition || uppercase }}</label
+        >
       </div>
     </div>
   </ng-template>
 </div>
 
-<div #treeContainer (transitionend)="transitionEnd($event)" [ngClass]="getClassNames('treeContainer', data.collapsed ? 'collapsed' : null)">
+<div
+  #treeContainer
+  (transitionend)="transitionEnd($event)"
+  [ngClass]="
+    getClassNames('treeContainer', data.collapsed ? 'collapsed' : null)
+  "
+>
   <ul [ngClass]="getClassNames('tree')" *ngIf="data && data.rules">
-    <ng-container *ngFor="let rule of data.rules;let i=index">
-
-      <ng-container *ngIf="{ruleset: !!rule.rules, invalid: !config.allowEmptyRulesets && rule.rules && rule.rules.length === 0} as local">
+    <ng-container *ngFor="let rule of data.rules; let i = index">
+      <ng-container
+        *ngIf="{
+          ruleset: !!rule.rules,
+          invalid:
+            !config.allowEmptyRulesets && rule.rules && rule.rules.length === 0
+        } as local"
+      >
         <li [ngClass]="getQueryItemClassName(local)">
           <ng-container *ngIf="!local.ruleset">
-
-            <ng-container *ngIf="getRemoveButtonTemplate() as template; else defaultRemoveButton">
+            <ng-container
+              *ngIf="
+                getRemoveButtonTemplate() as template;
+                else defaultRemoveButton
+              "
+            >
               <div [ngClass]="getClassNames('buttonGroup', 'rightAlign')">
-                <ng-container *ngTemplateOutlet="template; context: getRemoveButtonContext(rule)"></ng-container>
+                <ng-container
+                  *ngTemplateOutlet="
+                    template;
+                    context: getRemoveButtonContext(rule)
+                  "
+                ></ng-container>
               </div>
             </ng-container>
 
             <ng-template #defaultRemoveButton>
               <div [ngClass]="getClassNames('removeButtonSize', 'rightAlign')">
-                <button type="button" [ngClass]="getClassNames('button', 'removeButton')" (click)="removeRule(rule, data)" [disabled]=disabled>
+                <button
+                  type="button"
+                  [ngClass]="getClassNames('button', 'removeButton')"
+                  (click)="removeRule(rule, data)"
+                  [disabled]="disabled"
+                >
                   <i [ngClass]="getClassNames('removeIcon')"></i>
                 </button>
               </div>
             </ng-template>
 
             <div *ngIf="entities?.length > 0" class="q-inline-block-display">
-              <ng-container *ngIf="getEntityTemplate() as template; else defaultEntity">
-                <ng-container *ngTemplateOutlet="template; context: getEntityContext(rule)"></ng-container>
+              <ng-container
+                *ngIf="getEntityTemplate() as template; else defaultEntity"
+              >
+                <ng-container
+                  *ngTemplateOutlet="template; context: getEntityContext(rule)"
+                ></ng-container>
               </ng-container>
             </div>
 
             <ng-template #defaultEntity>
               <div [ngClass]="getClassNames('entityControlSize')">
-                <select [ngClass]="getClassNames('entityControl')" [(ngModel)]="rule.entity" (ngModelChange)="changeEntity($event, rule,i,data)"
-                  [disabled]="disabled">
-                  <option *ngFor="let entity of entities" [ngValue]="entity.value">
-                    {{entity.name}}
+                <select
+                  [ngClass]="getClassNames('entityControl')"
+                  [(ngModel)]="rule.entity"
+                  (ngModelChange)="changeEntity($event, rule, i, data)"
+                  [disabled]="disabled"
+                >
+                  <option
+                    *ngFor="let entity of entities"
+                    [ngValue]="entity.value"
+                  >
+                    {{ entity.name }}
                   </option>
                 </select>
               </div>
             </ng-template>
 
-            <ng-container *ngIf="getFieldTemplate() as template; else defaultField">
-              <ng-container *ngTemplateOutlet="template; context: getFieldContext(rule)"></ng-container>
+            <ng-container
+              *ngIf="getFieldTemplate() as template; else defaultField"
+            >
+              <ng-container
+                *ngTemplateOutlet="template; context: getFieldContext(rule)"
+              ></ng-container>
             </ng-container>
 
             <ng-template #defaultField>
               <div [ngClass]="getClassNames('fieldControlSize')">
-                <select [ngClass]="getClassNames('fieldControl')" [(ngModel)]="rule.field" (ngModelChange)="changeField($event, rule)"
-                  [disabled]="disabled">
-                  <option *ngFor="let field of getFields(rule.entity)" [ngValue]="field.value">
-                    {{field.name}}
+                <select
+                  [ngClass]="getClassNames('fieldControl')"
+                  [(ngModel)]="rule.field"
+                  (ngModelChange)="changeField($event, rule)"
+                  [disabled]="disabled"
+                >
+                  <option
+                    *ngFor="let field of getFields(rule.entity, rule)"
+                    [ngValue]="field.value"
+                  >
+                    {{ field.name }}
                   </option>
                 </select>
               </div>
             </ng-template>
 
-            <ng-container *ngIf="getOperatorTemplate() as template; else defaultOperator">
-              <ng-container *ngTemplateOutlet="template; context: getOperatorContext(rule)"></ng-container>
+            <ng-container
+              *ngIf="getOperatorTemplate() as template; else defaultOperator"
+            >
+              <ng-container
+                *ngTemplateOutlet="template; context: getOperatorContext(rule)"
+              ></ng-container>
             </ng-container>
 
             <ng-template #defaultOperator>
               <div [ngClass]="getClassNames('operatorControlSize')">
-                <select [ngClass]="getClassNames('operatorControl')" [(ngModel)]="rule.operator" (ngModelChange)="changeOperator(rule)"
-                  [disabled]="disabled">
-                  <option *ngFor="let operator of getOperators(rule.field)" [ngValue]="operator">
-                    {{operator}}
+                <select
+                  [ngClass]="getClassNames('operatorControl')"
+                  [(ngModel)]="rule.operator"
+                  (ngModelChange)="changeOperator(rule)"
+                  [disabled]="disabled"
+                >
+                  <option
+                    *ngFor="let operator of getOperators(rule.field)"
+                    [ngValue]="operator"
+                  >
+                    {{ operator }}
                   </option>
                 </select>
               </div>
             </ng-template>
 
-            <ng-container *ngIf="findTemplateForRule(rule) as template; else defaultInput">
-              <ng-container *ngTemplateOutlet="template; context: getInputContext(rule)"></ng-container>
+            <ng-container
+              *ngIf="findTemplateForRule(rule) as template; else defaultInput"
+            >
+              <ng-container
+                *ngTemplateOutlet="template; context: getInputContext(rule)"
+              ></ng-container>
             </ng-container>
 
             <ng-template #defaultInput>
-              <div [ngClass]="getClassNames('inputControlSize')" [ngSwitch]="getInputType(rule.field, rule.operator)">
-                <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                  [disabled]="disabled" *ngSwitchCase="'string'" type="text">
-                <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                  [disabled]="disabled" *ngSwitchCase="'number'" type="number">
-                <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                  [disabled]="disabled" *ngSwitchCase="'date'" type="date">
-                <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                  [disabled]="disabled" *ngSwitchCase="'time'" type="time">
-                <select [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                  [disabled]="disabled" *ngSwitchCase="'category'">
-                  <option *ngFor="let opt of getOptions(rule.field)" [ngValue]="opt.value">
-                    {{opt.name}}
+              <div
+                [ngClass]="getClassNames('inputControlSize')"
+                [ngSwitch]="getInputType(rule.field, rule.operator)"
+              >
+                <input
+                  [ngClass]="getClassNames('inputControl')"
+                  [(ngModel)]="rule.value"
+                  (ngModelChange)="changeInput()"
+                  [disabled]="disabled"
+                  *ngSwitchCase="'string'"
+                  type="text"
+                />
+                <input
+                  [ngClass]="getClassNames('inputControl')"
+                  [(ngModel)]="rule.value"
+                  (ngModelChange)="changeInput()"
+                  [disabled]="disabled"
+                  *ngSwitchCase="'number'"
+                  type="number"
+                />
+                <input
+                  [ngClass]="getClassNames('inputControl')"
+                  [(ngModel)]="rule.value"
+                  (ngModelChange)="changeInput()"
+                  [disabled]="disabled"
+                  *ngSwitchCase="'date'"
+                  type="date"
+                />
+                <input
+                  [ngClass]="getClassNames('inputControl')"
+                  [(ngModel)]="rule.value"
+                  (ngModelChange)="changeInput()"
+                  [disabled]="disabled"
+                  *ngSwitchCase="'time'"
+                  type="time"
+                />
+                <select
+                  [ngClass]="getClassNames('inputControl')"
+                  [(ngModel)]="rule.value"
+                  (ngModelChange)="changeInput()"
+                  [disabled]="disabled"
+                  *ngSwitchCase="'category'"
+                >
+                  <option
+                    *ngFor="let opt of getOptions(rule.field)"
+                    [ngValue]="opt.value"
+                  >
+                    {{ opt.name }}
                   </option>
                 </select>
                 <ng-container *ngSwitchCase="'multiselect'">
-                  <select [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                    [disabled]="disabled" multiple>
-                    <option *ngFor="let opt of getOptions(rule.field)" [ngValue]="opt.value">
-                      {{opt.name}}
+                  <select
+                    [ngClass]="getClassNames('inputControl')"
+                    [(ngModel)]="rule.value"
+                    (ngModelChange)="changeInput()"
+                    [disabled]="disabled"
+                    multiple
+                  >
+                    <option
+                      *ngFor="let opt of getOptions(rule.field)"
+                      [ngValue]="opt.value"
+                    >
+                      {{ opt.name }}
                     </option>
                   </select>
                 </ng-container>
-                <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                  [disabled]="disabled" *ngSwitchCase="'boolean'" type="checkbox">
+                <input
+                  [ngClass]="getClassNames('inputControl')"
+                  [(ngModel)]="rule.value"
+                  (ngModelChange)="changeInput()"
+                  [disabled]="disabled"
+                  *ngSwitchCase="'boolean'"
+                  type="checkbox"
+                />
               </div>
             </ng-template>
-
           </ng-container>
-          <query-builder *ngIf="local.ruleset" [data]="rule" [disabled]="disabled" [parentTouchedCallback]="parentTouchedCallback || onTouchedCallback"
-            [parentChangeCallback]="parentChangeCallback || onChangeCallback" [parentInputTemplates]="parentInputTemplates || inputTemplates"
-            [parentOperatorTemplate]="parentOperatorTemplate || operatorTemplate" [parentFieldTemplate]="parentFieldTemplate || fieldTemplate"
-            [parentEntityTemplate]="parentEntityTemplate || entityTemplate" [parentSwitchGroupTemplate]="parentSwitchGroupTemplate || switchGroupTemplate"
-            [parentButtonGroupTemplate]="parentButtonGroupTemplate || buttonGroupTemplate" [parentRemoveButtonTemplate]="parentRemoveButtonTemplate || removeButtonTemplate"
-            [parentEmptyWarningTemplate]="parentEmptyWarningTemplate || emptyWarningTemplate" [parentArrowIconTemplate]="parentArrowIconTemplate || arrowIconTemplate"
-            [parentValue]="data" [classNames]="classNames" [config]="config" [allowRuleset]="allowRuleset"
-            [allowCollapse]="allowCollapse" [emptyMessage]="emptyMessage" [operatorMap]="operatorMap">
+          <query-builder
+            *ngIf="local.ruleset"
+            [data]="rule"
+            [disabled]="disabled"
+            [parentTouchedCallback]="parentTouchedCallback || onTouchedCallback"
+            [parentChangeCallback]="parentChangeCallback || onChangeCallback"
+            [parentInputTemplates]="parentInputTemplates || inputTemplates"
+            [parentOperatorTemplate]="
+              parentOperatorTemplate || operatorTemplate
+            "
+            [parentFieldTemplate]="parentFieldTemplate || fieldTemplate"
+            [parentEntityTemplate]="parentEntityTemplate || entityTemplate"
+            [parentSwitchGroupTemplate]="
+              parentSwitchGroupTemplate || switchGroupTemplate
+            "
+            [parentButtonGroupTemplate]="
+              parentButtonGroupTemplate || buttonGroupTemplate
+            "
+            [parentRemoveButtonTemplate]="
+              parentRemoveButtonTemplate || removeButtonTemplate
+            "
+            [parentEmptyWarningTemplate]="
+              parentEmptyWarningTemplate || emptyWarningTemplate
+            "
+            [parentArrowIconTemplate]="
+              parentArrowIconTemplate || arrowIconTemplate
+            "
+            [parentValue]="data"
+            [classNames]="classNames"
+            [config]="config"
+            [allowRuleset]="allowRuleset"
+            [allowCollapse]="allowCollapse"
+            [emptyMessage]="emptyMessage"
+            [operatorMap]="operatorMap"
+          >
           </query-builder>
 
-          <ng-container *ngIf="getEmptyWarningTemplate() as template; else defaultEmptyWarning">
+          <ng-container
+            *ngIf="
+              getEmptyWarningTemplate() as template;
+              else defaultEmptyWarning
+            "
+          >
             <ng-container *ngIf="local.invalid">
-              <ng-container *ngTemplateOutlet="template; context: getEmptyWarningContext()"></ng-container>
+              <ng-container
+                *ngTemplateOutlet="template; context: getEmptyWarningContext()"
+              ></ng-container>
             </ng-container>
           </ng-container>
 
           <ng-template #defaultEmptyWarning>
             <p [ngClass]="getClassNames('emptyWarning')" *ngIf="local.invalid">
-              {{emptyMessage}}
+              {{ emptyMessage }}
             </p>
           </ng-template>
         </li>

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
@@ -708,7 +708,6 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
         getDisabledState: this.getDisabledState,
         fields: this.fields,
         $implicit: rule,
-        ruleSet: this.data,
       });
     }
     return this.fieldContextCache.get(rule);

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts
@@ -4,7 +4,7 @@ import {
   NG_VALUE_ACCESSOR,
   NG_VALIDATORS,
   ValidationErrors,
-  Validator
+  Validator,
 } from '@angular/forms';
 import { QueryOperatorDirective } from './query-operator.directive';
 import { QueryFieldDirective } from './query-field.directive';
@@ -47,26 +47,26 @@ import {
   SimpleChanges,
   TemplateRef,
   ViewChild,
-  ElementRef
+  ElementRef,
 } from '@angular/core';
 
 export const CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => QueryBuilderComponent),
-  multi: true
+  multi: true,
 };
 
 export const VALIDATOR: any = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => QueryBuilderComponent),
-  multi: true
+  multi: true,
 };
 
 @Component({
   selector: 'query-builder',
   templateUrl: './query-builder.component.html',
   styleUrls: ['./query-builder.component.scss'],
-  providers: [CONTROL_VALUE_ACCESSOR, VALIDATOR]
+  providers: [CONTROL_VALUE_ACCESSOR, VALIDATOR],
 })
 export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAccessor, Validator {
   public fields: Field[];
@@ -101,7 +101,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     operatorControl: 'q-operator-control',
     operatorControlSize: 'q-control-size',
     inputControl: 'q-input-control',
-    inputControlSize: 'q-control-size'
+    inputControlSize: 'q-control-size',
   };
   public defaultOperatorMap: { [key: string]: string[] } = {
     string: ['=', '!=', 'contains', 'like'],
@@ -109,7 +109,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     time: ['=', '!=', '>', '>=', '<', '<='],
     date: ['=', '!=', '>', '>=', '<', '<='],
     category: ['=', '!=', 'in', 'not in'],
-    boolean: ['=']
+    boolean: ['='],
   };
   @Input() disabled: boolean;
   @Input() data: RuleSet = { condition: 'and', rules: [] };
@@ -123,6 +123,9 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   @Input() emptyMessage: string = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
   @Input() classNames: QueryBuilderClassNames;
   @Input() operatorMap: { [key: string]: string[] };
+  @Input() conditions: string[] = ['or', 'and'];
+  @Input() minNestedLevel = 0;
+  @Input() maxNestedLevel = 10;
   @Input() parentValue: RuleSet;
   @Input() config: QueryBuilderConfig = { fields: {} };
   @Input() parentArrowIconTemplate: QueryArrowIconDirective;
@@ -138,22 +141,26 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   @Input() parentTouchedCallback: () => void;
   @Input() persistValueOnFieldChange: boolean = false;
 
-  @ViewChild('treeContainer', {static: true}) treeContainer: ElementRef;
+  @ViewChild('treeContainer', { static: true }) treeContainer: ElementRef;
 
-  @ContentChild(QueryButtonGroupDirective) buttonGroupTemplate: QueryButtonGroupDirective;
-  @ContentChild(QuerySwitchGroupDirective) switchGroupTemplate: QuerySwitchGroupDirective;
+  @ContentChild(QueryButtonGroupDirective)
+  buttonGroupTemplate: QueryButtonGroupDirective;
+  @ContentChild(QuerySwitchGroupDirective)
+  switchGroupTemplate: QuerySwitchGroupDirective;
   @ContentChild(QueryFieldDirective) fieldTemplate: QueryFieldDirective;
   @ContentChild(QueryEntityDirective) entityTemplate: QueryEntityDirective;
-  @ContentChild(QueryOperatorDirective) operatorTemplate: QueryOperatorDirective;
-  @ContentChild(QueryRemoveButtonDirective) removeButtonTemplate: QueryRemoveButtonDirective;
-  @ContentChild(QueryEmptyWarningDirective) emptyWarningTemplate: QueryEmptyWarningDirective;
+  @ContentChild(QueryOperatorDirective)
+  operatorTemplate: QueryOperatorDirective;
+  @ContentChild(QueryRemoveButtonDirective)
+  removeButtonTemplate: QueryRemoveButtonDirective;
+  @ContentChild(QueryEmptyWarningDirective)
+  emptyWarningTemplate: QueryEmptyWarningDirective;
   @ContentChildren(QueryInputDirective) inputTemplates: QueryList<QueryInputDirective>;
-  @ContentChild(QueryArrowIconDirective) arrowIconTemplate: QueryArrowIconDirective;
+  @ContentChild(QueryArrowIconDirective)
+  arrowIconTemplate: QueryArrowIconDirective;
 
-  private defaultTemplateTypes: string[] = [
-    'string', 'number', 'time', 'date', 'category', 'boolean', 'multiselect'];
-  private defaultPersistValueTypes: string[] = [
-    'string', 'number', 'time', 'date', 'boolean'];
+  private defaultTemplateTypes: string[] = ['string', 'number', 'time', 'date', 'category', 'boolean', 'multiselect'];
+  private defaultPersistValueTypes: string[] = ['string', 'number', 'time', 'date', 'boolean'];
   private defaultEmptyList: any[] = [];
   private operatorsCache: { [key: string]: string[] };
   private inputContextCache = new Map<Rule, InputContext>();
@@ -163,11 +170,11 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   private removeButtonContextCache = new Map<Rule, RemoveButtonContext>();
   private buttonGroupContext: ButtonGroupContext;
 
-  constructor(private changeDetectorRef: ChangeDetectorRef) { }
+  constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
   // ----------OnInit Implementation----------
 
-  ngOnInit() { }
+  ngOnInit() {}
 
   // ----------OnChanges Implementation----------
 
@@ -284,11 +291,13 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     if (fieldObject && fieldObject.operators) {
       operators = fieldObject.operators;
     } else if (type) {
-      operators = (this.operatorMap && this.operatorMap[type]) || this.defaultOperatorMap[type] || this.defaultEmptyList;
+      operators =
+        (this.operatorMap && this.operatorMap[type]) || this.defaultOperatorMap[type] || this.defaultEmptyList;
       if (operators.length === 0) {
         console.warn(
           `No operators found for field '${field}' with type ${fieldObject.type}. ` +
-          `Please define an 'operators' property on the field or use the 'operatorMap' binding to fix this.`);
+            `Please define an 'operators' property on the field or use the 'operatorMap' binding to fix this.`,
+        );
       }
       if (fieldObject.nullable) {
         operators = operators.concat(['is null', 'is not null']);
@@ -302,14 +311,27 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     return operators;
   }
 
-  getFields(entity: string): Field[] {
+  getParentRuleSet(rule: Rule, parentRules: Array<Rule | RuleSet>): RuleSet {
+    const ruleSet = parentRules.find((parentRule) => parentRule.index === rule.parentIndex);
+    if (ruleSet) {
+      return ruleSet as RuleSet;
+    }
+    const childrenRuleSet = (parentRules as RuleSet[]).filter((parentRule) => parentRule.rules);
+    return this.getParentRuleSet(rule, childrenRuleSet);
+  }
+
+  getFields(entity: string, rule: Rule): Field[] {
+    if (this.config.getFields) {
+      const ruleSet = this.getParentRuleSet(rule, this.data.rules);
+      return this.config.getFields(rule, ruleSet);
+    }
+
     if (this.entities && entity) {
       return this.fields.filter((field) => {
         return field && field.entity === entity;
       });
-    } else {
-      return this.fields;
     }
+    return this.fields;
   }
 
   getInputType(field: string, operator: string): string {
@@ -325,7 +347,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     switch (operator) {
       case 'is null':
       case 'is not null':
-        return null;  // No displayed component
+        return null; // No displayed component
       case 'in':
       case 'not in':
         return type === 'category' || type === 'boolean' ? 'multiselect' : type;
@@ -359,8 +381,10 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
       if (entityFields && entityFields.length) {
         return entityFields[0];
       } else {
-        console.warn(`No fields found for entity '${entity.name}'. ` +
-          `A 'defaultOperator' is also not specified on the field config. Operator value will default to null.`);
+        console.warn(
+          `No fields found for entity '${entity.name}'. ` +
+            `A 'defaultOperator' is also not specified on the field config. Operator value will default to null.`,
+        );
         return null;
       }
     }
@@ -374,8 +398,10 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
       if (operators && operators.length) {
         return operators[0];
       } else {
-        console.warn(`No operators found for field '${field.value}'. ` +
-          `A 'defaultOperator' is also not specified on the field config. Operator value will default to null.`);
+        console.warn(
+          `No operators found for field '${field.value}'. ` +
+            `A 'defaultOperator' is also not specified on the field config. Operator value will default to null.`,
+        );
         return null;
       }
     }
@@ -391,12 +417,14 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
       this.config.addRule(parent);
     } else {
       const field = this.fields[0];
-      parent.rules = parent.rules.concat([{
-        field: field.value,
-        operator: this.getDefaultOperator(field),
-        value: this.getDefaultValue(field.defaultValue),
-        entity: field.entity
-      }]);
+      parent.rules = parent.rules.concat([
+        {
+          field: field.value,
+          operator: this.getDefaultOperator(field),
+          value: this.getDefaultValue(field.defaultValue),
+          entity: field.entity,
+        },
+      ]);
     }
 
     this.handleTouched();
@@ -457,6 +485,18 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     this.handleDataChange();
   }
 
+  addRuleSetDisabled(ruleset: RuleSet): boolean {
+    return ruleset.depth >= this.maxNestedLevel;
+  }
+
+  addRuleDisabled(ruleset: RuleSet): boolean {
+    return false;
+  }
+
+  removeRuleSetDisabled(ruleset: RuleSet): boolean {
+    return false;
+  }
+
   transitionEnd(e: Event): void {
     this.treeContainer.nativeElement.style.maxHeight = null;
   }
@@ -471,8 +511,13 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   computedTreeContainerHeight(): void {
     const nativeElement: HTMLElement = this.treeContainer.nativeElement;
     if (nativeElement && nativeElement.firstElementChild) {
-      nativeElement.style.maxHeight = (nativeElement.firstElementChild.clientHeight + 8) + 'px';
+      nativeElement.style.maxHeight = nativeElement.firstElementChild.clientHeight + 8 + 'px';
     }
+  }
+
+  getConditions(ruleset?: RuleSet): string[] {
+    const conditions = this.config.getConditions ? this.config.getConditions(ruleset) : this.conditions;
+    return conditions;
   }
 
   changeCondition(value: string): void {
@@ -527,8 +572,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
 
     const nextField: Field = this.config.fields[fieldValue];
 
-    const nextValue = this.calculateFieldChangeValue(
-      currentField, nextField, rule.value);
+    const nextValue = this.calculateFieldChangeValue(currentField, nextField, rule.value);
 
     if (nextValue !== undefined) {
       rule.value = nextValue;
@@ -639,7 +683,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
         addRuleSet: this.allowRuleset && this.addRuleSet.bind(this),
         removeRuleSet: this.allowRuleset && this.parentValue && this.removeRuleSet.bind(this),
         getDisabledState: this.getDisabledState,
-        $implicit: this.data
+        $implicit: this.data,
       };
     }
     return this.buttonGroupContext;
@@ -650,7 +694,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
       this.removeButtonContextCache.set(rule, {
         removeRule: this.removeRule.bind(this),
         getDisabledState: this.getDisabledState,
-        $implicit: rule
+        $implicit: rule,
       });
     }
     return this.removeButtonContextCache.get(rule);
@@ -663,7 +707,8 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
         getFields: this.getFields.bind(this),
         getDisabledState: this.getDisabledState,
         fields: this.fields,
-        $implicit: rule
+        $implicit: rule,
+        ruleSet: this.data,
       });
     }
     return this.fieldContextCache.get(rule);
@@ -675,7 +720,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
         onChange: this.changeEntity.bind(this),
         getDisabledState: this.getDisabledState,
         entities: this.entities,
-        $implicit: rule
+        $implicit: rule,
       });
     }
     return this.entityContextCache.get(rule);
@@ -684,15 +729,16 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
   getSwitchGroupContext(): SwitchGroupContext {
     return {
       onChange: this.changeCondition.bind(this),
+      getConditions: this.getConditions.bind(this),
       getDisabledState: this.getDisabledState,
-      $implicit: this.data
+      $implicit: this.data,
     };
   }
 
   getArrowIconContext(): ArrowIconContext {
     return {
       getDisabledState: this.getDisabledState,
-      $implicit: this.data
+      $implicit: this.data,
     };
   }
 
@@ -700,7 +746,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     return {
       getDisabledState: this.getDisabledState,
       message: this.emptyMessage,
-      $implicit: this.data
+      $implicit: this.data,
     };
   }
 
@@ -710,7 +756,7 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
         onChange: this.changeOperator.bind(this),
         getDisabledState: this.getDisabledState,
         operators: this.getOperators(rule.field),
-        $implicit: rule
+        $implicit: rule,
       });
     }
     return this.operatorContextCache.get(rule);
@@ -723,29 +769,22 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
         getDisabledState: this.getDisabledState,
         options: this.getOptions(rule.field),
         field: this.config.fields[rule.field],
-        $implicit: rule
+        $implicit: rule,
       });
     }
     return this.inputContextCache.get(rule);
   }
 
-  private calculateFieldChangeValue(
-    currentField: Field,
-    nextField: Field,
-    currentValue: any
-  ): any {
-
+  private calculateFieldChangeValue(currentField: Field, nextField: Field, currentValue: any): any {
     if (this.config.calculateFieldChangeValue != null) {
-      return this.config.calculateFieldChangeValue(
-        currentField, nextField, currentValue);
+      return this.config.calculateFieldChangeValue(currentField, nextField, currentValue);
     }
 
     const canKeepValue = () => {
       if (currentField == null || nextField == null) {
         return false;
       }
-      return currentField.type === nextField.type
-        && this.defaultPersistValueTypes.indexOf(currentField.type) !== -1;
+      return currentField.type === nextField.type && this.defaultPersistValueTypes.indexOf(currentField.type) !== -1;
     };
 
     if (this.persistValueOnFieldChange && canKeepValue()) {
@@ -791,8 +830,21 @@ export class QueryBuilderComponent implements OnInit, OnChanges, ControlValueAcc
     }
   }
 
+  private addMetadata(arr = [], depth = 1, parentIndex = 0) {
+    arr.forEach((obj, index) => {
+      obj.parentIndex = parentIndex;
+      obj.index = index;
+      obj.depth = depth;
+      if (obj.rules) {
+        this.addMetadata(obj.rules, depth + 1, index);
+      }
+    });
+  }
+
   private handleDataChange(): void {
     this.changeDetectorRef.markForCheck();
+    this.addMetadata(this.data.rules || []);
+
     if (this.onChangeCallback) {
       this.onChangeCallback();
     }

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
@@ -5,6 +5,9 @@ export interface RuleSet {
   rules: Array<RuleSet | Rule>;
   collapsed?: boolean;
   isChild?: boolean;
+  depth?: number;
+  index?: number;
+  parentIndex?: number;
 }
 
 export interface Rule {
@@ -12,6 +15,9 @@ export interface Rule {
   value?: any;
   operator?: string;
   entity?: string;
+  depth?: number;
+  index?: number;
+  parentIndex?: number;
 }
 
 export interface Option {
@@ -98,13 +104,18 @@ export interface QueryBuilderConfig {
   removeRuleSet?: (ruleset: RuleSet, parent: RuleSet) => void;
   removeRule?: (rule: Rule, parent: RuleSet) => void;
   coerceValueForOperator?: (operator: string, value: any, rule: Rule) => any;
-  calculateFieldChangeValue?: (currentField: Field,
-                               nextField: Field,
-                               currentValue: any) => any;
+  calculateFieldChangeValue?: (
+    currentField: Field,
+    nextField: Field,
+    currentValue: any
+  ) => any;
+  getConditions?: (ruleset?: RuleSet) => string[];
+  getFields?: (rule: Rule, ruleSet: RuleSet) => Field[];
 }
 
 export interface SwitchGroupContext {
   onChange: (conditionValue: string) => void;
+  getConditions: (ruleset?: RuleSet) => string[];
   getDisabledState: () => boolean;
   $implicit: RuleSet;
 }
@@ -132,6 +143,7 @@ export interface FieldContext {
   getFields: (entityName: string) => void;
   getDisabledState: () => boolean;
   fields: Field[];
+  ruleSet: RuleSet;
   $implicit: Rule;
 }
 

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.interfaces.ts
@@ -143,7 +143,6 @@ export interface FieldContext {
   getFields: (entityName: string) => void;
   getDisabledState: () => boolean;
   fields: Field[];
-  ruleSet: RuleSet;
   $implicit: Rule;
 }
 


### PR DESCRIPTION
Hey, i would like to propose you some little changes in your excellent library, sorry in advance for the lint changes, it will be fixed on another commit if you require it.

Currently we're using it in a project and we needed the ability to customize the conditions, fields and buttons based on the context of the tree.

So first, i added a function to add metadata to the rules / rulesets when changes occur and extended the Rule and RuleSet interfaces with `depth`, `index` and `parentIndex`.
Then i created several other functions :
- to check the ruleset depth to control how to display the buttons.
- to retrieve the parent ruleset from a field so that we can apply logic on how to display the fields list
- to display conditions and fields in a custom way with `getConditions` and `getFields` that can be overridden in `queryBuilderConfig`

I would be happy to know your feedback and bring further explanations if needed.