### PR TITLE
human readable expression pipe

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -14,6 +14,8 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from 'angular2-query-build
     </ng-container>
   </query-builder>
   <br>
+  <div><strong>Expression:</strong> {{query | expressionFormat:entityConfig}}</div>
+  <br>
   <div>
     <div class="row">
       <p class="col-6">Control Valid (Vanilla): {{ queryCtrl.valid }}</p>

--- a/projects/angular2-query-builder/src/lib/angular2-query-builder.module.ts
+++ b/projects/angular2-query-builder/src/lib/angular2-query-builder.module.ts
@@ -13,6 +13,7 @@ import { QueryButtonGroupDirective } from './query-builder/query-button-group.di
 import { QuerySwitchGroupDirective } from './query-builder/query-switch-group.directive';
 import { QueryRemoveButtonDirective } from './query-builder/query-remove-button.directive';
 import { QueryEmptyWarningDirective } from './query-builder/query-empty-warning.directive';
+import {QueryBuilderExpressionPipe} from "./query-builder/query-builder-expression.pipe";
 
 @NgModule({
   imports: [
@@ -29,7 +30,8 @@ import { QueryEmptyWarningDirective } from './query-builder/query-empty-warning.
     QuerySwitchGroupDirective,
     QueryRemoveButtonDirective,
     QueryEmptyWarningDirective,
-    QueryArrowIconDirective
+    QueryArrowIconDirective,
+    QueryBuilderExpressionPipe
   ],
   exports: [
     QueryBuilderComponent,
@@ -41,7 +43,8 @@ import { QueryEmptyWarningDirective } from './query-builder/query-empty-warning.
     QuerySwitchGroupDirective,
     QueryRemoveButtonDirective,
     QueryEmptyWarningDirective,
-    QueryArrowIconDirective
+    QueryArrowIconDirective,
+    QueryBuilderExpressionPipe
   ]
 })
 export class QueryBuilderModule { }

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder-expression.pipe.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder-expression.pipe.ts
@@ -1,0 +1,111 @@
+import {Pipe, PipeTransform, Query} from '@angular/core';
+import {QueryBuilderConfig} from "./query-builder.interfaces";
+
+
+@Pipe({name: 'expressionFormat',  pure: false})
+
+export class QueryBuilderExpressionPipe implements PipeTransform {
+
+  transform(query: Query, queryConfig: QueryBuilderConfig): string {
+    return this.computed(query, queryConfig);
+
+  }
+
+  defineCondition(rule){
+    return rule.condition ? rule.condition : rule.operator;
+  }
+
+  getInputType(config : QueryBuilderConfig, field: string, operator: string): string {
+    if (config.getInputType) {
+      return config.getInputType(field, operator);
+    }
+
+    if (!config.fields[field]) {
+      throw new Error(`No configuration for field '${field}' could be found! Please add it to config.fields.`);
+    }
+
+    const type = config.fields[field].type;
+    switch (operator) {
+      case 'is null':
+      case 'is not null':
+        return null;  // No displayed component
+      case 'in':
+      case 'not in':
+        return type === 'category' || type === 'boolean' ? 'multiselect' : type;
+      default:
+        return type;
+    }
+  }
+
+  defineMultiselect(rule){
+    let value = rule.value || [];
+    return JSON.stringify(value);
+  }
+
+  defineString(rule){
+    let value = rule.value || "";
+    return JSON.stringify(value);
+  }
+
+
+  private defineDate(rule) {
+    let value = rule.value || "";
+    return JSON.stringify(value);
+  }
+
+  private defineNumber(rule) {
+
+    if (typeof rule.value  === 'undefined'){
+      return "?";
+    }
+
+    return rule.value;
+  }
+
+  private defineBoolean(rule) {
+    let value = rule.value ? true : false;
+    return JSON.stringify(value);
+  }
+
+  defineValue(rule, queryConfig : QueryBuilderConfig){
+
+    let format = this.getInputType(queryConfig, rule.field, rule.operator);
+
+    if (!format){
+      return '';
+    }
+
+    switch (format){
+      case 'number' : return this.defineNumber(rule)
+      case 'boolean' : return this.defineBoolean(rule);
+      case 'string' : return this.defineString(rule)
+      case 'category' : return this.defineString(rule);
+      case 'multiselect' : return this.defineMultiselect(rule);
+      case 'date' : return this.defineDate(rule);
+      default : return this.defineString(rule)
+    }
+  }
+
+  computed = function (group, queryConfig) {
+    let str = "";
+
+    if (!group) {
+      return str;
+    }
+    str += " (";
+
+    let myMap = group.rules.map((rule) => {
+      let newStr = "";
+      if (rule.condition && rule.rules) {
+        newStr = this.computed(rule, queryConfig);
+      } else {
+        newStr = [rule.field,this.defineCondition(rule), this.defineValue(rule, queryConfig)].join(" ");
+      }
+      return newStr;
+    });
+    str += myMap.join(" " +group.condition.toUpperCase()+ " ");
+    str += ")";
+    return str;
+  };
+
+}

--- a/projects/angular2-query-builder/src/public-api.ts
+++ b/projects/angular2-query-builder/src/public-api.ts
@@ -15,5 +15,7 @@ export * from './lib/query-builder/query-switch-group.directive';
 export * from './lib/query-builder/query-remove-button.directive';
 export * from './lib/query-builder/query-empty-warning.directive';
 export * from './lib/query-builder/query-arrow-icon.directive';
+export * from './lib/query-builder/query-builder-expression.pipe';
 
 export * from './lib/angular2-query-builder.module';
+


### PR DESCRIPTION
Created a `expressionFormat` pipe to get in a human readable format.

```html
 <div><strong>Expression:</strong> {{query | expressionFormat:entityConfig}}</div>
```

![image](https://user-images.githubusercontent.com/554537/111160323-bd187b00-8578-11eb-9010-457dcd241e00.png)
